### PR TITLE
Updated nuget references to release version

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - 'main'
   release:
-    types: [created]
+    types: [published]
 
 env:
   DOTNET_VERSION: '3.1.200'

--- a/src/Microsoft.AzureIntegrationMigration.ApplicationModel/Microsoft.AzureIntegrationMigration.ApplicationModel.csproj
+++ b/src/Microsoft.AzureIntegrationMigration.ApplicationModel/Microsoft.AzureIntegrationMigration.ApplicationModel.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.2.0-alpha.2020100155692" />
+    <PackageReference Include="Microsoft.AzureIntegrationMigration.Runner" Version="0.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.6.0-beta1-20111-10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description
- Updated the aimcore nuget reference to the release version.
- Changed release event type to published to allow draft releases to be created without triggering a CI workflow, until the release is published.